### PR TITLE
Added es2015 babel for safari support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
     "css-loader": "^0.24.0",
     "escape-html": "^1.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ module.exports = {
     loaders: [
       { test: /\.js$/, exclude: '/node_modules/', loader: 'babel-loader' },
       { test: /\.css$/, loader: 'style!css' },
-      { test: /\.scss$/, loader: 'style!css!sass' }
+      { test: /\.scss$/, loader: 'style!css!sass' },
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?presets[]=es2015' }
     ]
   },
   resolve: {


### PR DESCRIPTION
On our tier 1 project we needed to add es2015 support in order to get Safari to render our SCSS files. I've added those dependencies. 
